### PR TITLE
Relax GSAB byte length accesses to unordered for get/set

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -975,6 +975,27 @@
   </emu-clause>
 </emu-clause>
 
+<emu-clause id="sec-abstract-operations-for-atomics-mods">
+  <h1>Modifications to Abstract Operations for Atomics</h1>
+
+  <emu-clause id="sec-validateatomicaccess" aoid="ValidateAtomicAccess">
+    <h1>ValidateAtomicAccess ( _typedArray_, _requestIndex_ )</h1>
+    <p>The abstract operation ValidateAtomicAccess takes arguments _typedArray_ and _requestIndex_. It performs the following steps when called:</p>
+    <emu-alg>
+      1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
+      1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+      1. Let _length_ be <del>_typedArray_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_typedArray_)</ins>.
+      1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
+      1. Assert: _accessIndex_ &ge; 0.
+      1. If _accessIndex_ &ge; _length_, throw a *RangeError* exception.
+      1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
+      1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+      1. Let _offset_ be _typedArray_.[[ByteOffset]].
+      1. Return (_accessIndex_ &times; _elementSize_) + _offset_.
+    </emu-alg>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="omitted-for-brevity">
   <h1>Mechanical Changes Omitted for Brevity</h1>
   <ul>

--- a/spec.html
+++ b/spec.html
@@ -543,7 +543,7 @@
     <emu-alg>
       1. Let _keys_ be a new empty List.
       1. Assert: _O_ is an Integer-Indexed exotic object.
-      1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+      1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
       1. <del>Let _len_ be _O_.[[ArrayLength]]</del>.
       1. <ins>Let _len_ be IntegerIndexedObjectLength(_O_, _getBufferByteLength_).</ins>
       1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
@@ -564,9 +564,9 @@
       1. Assert: Type(_index_) is Number.
       1. If ! IsInteger(_index_) is *false*, return *false*.
       1. If _index_ is *-0*<sub>𝔽</sub>, return *false*.
-      1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+      1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
       1. <ins>NOTE: Bounds checking is not a synchronizing operation when _O_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
-      1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return *false*.</ins>
+      1. <ins>If IsIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return *false*.</ins>
       1. If ℝ(_index_) &lt; 0 or ℝ(_index_) &ge; <del>_O_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_O_, _getBufferByteLength_)</ins>, return *false*.
       1. Return *true*.
     </emu-alg>
@@ -591,7 +591,7 @@
     <p>The abstract operation IntegerIndexedObjectLength takes arguments _O_ and _getBufferByteLength_. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _O_ is an Integer-Indexed exotic object.
-      1. If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return 0.
+      1. If IsIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return 0.
       1. If _O_.[[ArrayLength]] is not ~auto~, return _O_.[[ArrayLength]].
       1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
       1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).
@@ -603,9 +603,9 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-checkintegerindexedobjectoutofbounds" aoid="CheckIntegerIndexedObjectOutOfBounds">
-    <h1>CheckIntegerIndexedObjectOutOfBounds ( _O_, _getBufferByteLength_ )</h1>
-    <p>The abstract operation CheckIntegerIndexedObjectOutOfBounds takes arguments _O_ and _getBufferByteLength_. It checks if any part of the underlying viewed buffer is out of bounds. It performs the following steps when called:</p>
+  <emu-clause id="sec-isintegerindexedobjectoutofbounds" aoid="IsIntegerIndexedObjectOutOfBounds">
+    <h1>IsIntegerIndexedObjectOutOfBounds ( _O_, _getBufferByteLength_ )</h1>
+    <p>The abstract operation IsIntegerIndexedObjectOutOfBounds takes arguments _O_ and _getBufferByteLength_. It checks if any part of the underlying viewed buffer is out of bounds. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _O_ is an Integer-Indexed exotic object.
       1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
@@ -637,8 +637,8 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
-        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>If IsIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Return _buffer_.
       </emu-alg>
     </emu-clause>
@@ -652,7 +652,7 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
         1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>IntegerIndexedObjectByteLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_size_).
       </emu-alg>
@@ -667,8 +667,8 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
-        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return *+0*<sub>𝔽</sub>.</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>If IsIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return *+0*<sub>𝔽</sub>.</ins>
         1. Let _offset_ be _O_.[[ByteOffset]].
         1. Return 𝔽(_offset_).
       </emu-alg>
@@ -683,7 +683,7 @@
         1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).
+        1. Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).
         1. Let _length_ be <del>_O_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_length_).
       </emu-alg>
@@ -697,11 +697,11 @@
         1. Assert: _source_ is an Object that has a [[TypedArrayName]] internal slot.
         1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>Let _getSrcBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>Let _getSrcBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
         1. Let _targetLength_ be <del>_target_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_target_, _getBufferByteLength_)</ins>.
         1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_target_, getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>If IsIntegerIndexedObjectOutOfBounds(_target_, getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
         1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
         1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
@@ -755,7 +755,7 @@
         1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
         1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
-        1. <ins>Let _getSrcBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>Let _getSrcBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
         1. Let _elementLength_ be <del>_srcArray_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_srcArray_, _getSrcBufferByteLength_)</ins>.
         1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
         1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
@@ -772,7 +772,7 @@
         1. Else,
           1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-          1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+          1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
           1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
           1. Let _srcByteIndex_ be _srcByteOffset_.
           1. Let _targetByteIndex_ be 0.
@@ -870,7 +870,7 @@
         1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
         1. <ins>NOTE: Bounds checking is not a synchronizing operation when _view_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
         1. <ins>If CheckViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _viewOffset_ be _view_.[[ByteOffset]].
@@ -894,7 +894,7 @@
         1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
         1. <ins>NOTE: Bounds checking is not a synchronizing operation when _view_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
         1. <ins>If CheckViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _viewOffset_ be _view_.[[ByteOffset]].
@@ -950,7 +950,7 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
         1. <ins>If CheckViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>GetViewByteLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_size_).
@@ -966,7 +966,7 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
         1. <ins>If CheckViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _offset_ be _O_.[[ByteOffset]].
         1. Return 𝔽(_offset_).
@@ -983,7 +983,7 @@
     <p>The abstract operation ValidateAtomicAccess takes arguments _typedArray_ and _requestIndex_. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _typedArray_ is an Object that has a [[ViewedArrayBuffer]] internal slot.
-      1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+      1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
       1. Let _length_ be <del>_typedArray_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_typedArray_)</ins>.
       1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
       1. Assert: _accessIndex_ &ge; 0.

--- a/spec.html
+++ b/spec.html
@@ -41,15 +41,31 @@
 
   <ins class="block">
   <emu-clause id="sec-arraybufferlength" aoid="ArrayBufferByteLength">
-    <h1>ArrayBufferByteLength ( _arrayBuffer_ )</h1>
-    <p>The abstract operation ArrayBufferByteLength takes argument _arrayBuffer_. It performs the following steps when called:</p>
+    <h1>ArrayBufferByteLength ( _arrayBuffer_, _order_ )</h1>
+    <p>The abstract operation ArrayBufferByteLength takes arguments _arrayBuffer_ and _order_ (either ~SeqCst~ or ~Unordered~). It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: Type(_arrayBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
       1. If IsSharedArrayBuffer(_arrayBuffer_) is *true* and _arrayBuffer_ has an [[ArrayBufferByteLengthData]] internal slot, then
         1. Let _bufferByteLengthBlock_ be _O_.[[ArrayBufferByteLengthData]].
-        1. Return ℝ(GetValueFromBuffer(_bufferByteLengthBlock_, 0, ~Uint64~, *true*, ~SeqCst~)).
+        1. Return ℝ(GetValueFromBuffer(_bufferByteLengthBlock_, 0, ~Uint64~, *true*, _order_)).
       1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
       1. Return _arrayBuffer_.[[ArrayBufferByteLength]].
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-makeidempotentarraybufferbytelengthgetter" aoid="MakeIdempotentArrayBufferByteLengthGetter">
+    <h1>MakeIdempotentArrayBufferByteLengthGetter ( _order_ )</h1>
+    <p>The abstract operation MakeIdempotentArrayBufferByteLengthGetter takes argument _order_ (either ~SeqCst~ or ~Unordered~). The returned Abstract Closure helps ensure that there there is a single shared memory read event of the byte length data block in the calling operation. It performs the following steps when called:</p>
+    <emu-alg>
+      1. NOTE: The [[ArrayBuffer]] slot is used for editorial clarity only, that a getter should only be used with a single ArrayBuffer.
+      1. Let _lengthStorage_ be { [[ArrayBuffer]]: ~empty~, [[ByteLength]]: ~empty~ }.
+      1. Let _getter_ be a new Abstract Closure with parameters (_buffer_) that captures _lengthStorage_, _buffer_, and _order_ and performs the following steps when called:
+        1. If _lengthStorage_.[[ByteLength]] is not ~empty~, then
+          1. Assert: _lengthStorage_.[[ArrayBuffer]] is ~empty~.
+          1. Set _lengthStorage_.[[ArrayBuffer]] to _buffer_.
+          1. Set _lengthStorage_.[[ByteLength]] to ArrayBufferByteLength(_buffer_, _order_).
+        1. Assert: SameValue(_lengthStorage_.[[ArrayBuffer]], _buffer_) is *true*.
+        1. Return _lengthStorage_.[[ByteLength]].
     </emu-alg>
   </emu-clause>
 
@@ -124,7 +140,8 @@
         1. Let _O_ be the *this* value.
         1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferMaxByteLength]]).
         1. If IsDetachedBuffer(_O_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. Let _length_ be ArrayBufferByteLength(_O_).
+        1. NOTE: The ~SeqCst~ argument below is ignored for ResizableArrayBuffer.
+        1. Let _length_ be ArrayBufferByteLength(_O_, ~SeqCst~).
         1. Return 𝔽(_length_).
       </emu-alg>
     </emu-clause>
@@ -313,7 +330,7 @@
         1. Let _O_ be the *this* value.
         1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferMaxByteLength]]).
         1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
-        1. Let _length_ be ArrayBufferByteLength(_O_).
+        1. Let _length_ be ArrayBufferByteLength(_O_, ~SeqCst~).
         1. Return 𝔽(_length_).
       </emu-alg>
     </emu-clause>
@@ -342,12 +359,12 @@
         1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferMaxByteLength]]).
         1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
         1. Let _newByteLength_ to ? ToIntegerOrInfinity(_newLength_).
-        1. If _newByteLength_ &ne; ArrayBufferByteLength(_O_), then
+        1. Let _currentByteLength_ be ArrayBufferByteLength(_O_, ~SeqCst~).
+        1. If _newByteLength_ &ne; _currentByteLength_, then
           1. Note: Resizes to the same length explicitly do nothing to avoid gratuitous synchronization.
-          1. If _newByteLength_ &lt; ArrayBufferByteLength(_O_) or _newByteLength_ &gt; _O_.[[ArrayBufferMaxByteLength]], throw a *RangeError* exception.
+          1. If _newByteLength_ &lt; _currentByteLength_ or _newByteLength_ &gt; _O_.[[ArrayBufferMaxByteLength]], throw a *RangeError* exception.
           1. Let _byteLengthBlock_ be _O_.[[ArrayBufferByteLengthData]].
           1. Perform SetValueInBuffer(_byteLengthBlock_, 0, ~Uint64~, 𝔽(_newByteLength_), *true*, ~SeqCst~).
-          1. TODO: Verify memory model event for the resize.
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -359,7 +376,7 @@
         1. Let _O_ be the *this* value.
         1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferMaxByteLength]]).
         1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
-        1. Let _len_ be ArrayBufferByteLength(_O_).
+        1. Let _len_ be ArrayBufferByteLength(_O_, ~SeqCst~).
         1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
         1. If _relativeStart_ is -&infin;, let _first_ be 0.
         1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
@@ -526,8 +543,9 @@
     <emu-alg>
       1. Let _keys_ be a new empty List.
       1. Assert: _O_ is an Integer-Indexed exotic object.
+      1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
       1. <del>Let _len_ be _O_.[[ArrayLength]]</del>.
-      1. <ins>Let _len_ be IntegerIndexedObjectLength(_O_).</ins>
+      1. <ins>Let _len_ be IntegerIndexedObjectLength(_O_, _getBufferByteLength_).</ins>
       1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
         1. Add ! ToString(_i_) as the last element of _keys_.
       1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an integer index, in ascending chronological order of property creation, do
@@ -540,41 +558,44 @@
 
   <emu-clause id="sec-isvalidintegerindex" aoid="IsValidIntegerIndex">
     <h1>IsValidIntegerIndex ( _O_, _index_ )</h1>
-    <p>The abstract operation IsValidIntegerIndex takes arguments _O_ and _index_. It performs the following steps when called:</p>
+    <p>The abstract operation IsValidIntegerIndex takes arguments _O_, _getBufferByteLength_, and _index_. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _O_ is an Integer-Indexed exotic object.
       1. Assert: Type(_index_) is Number.
       1. If ! IsInteger(_index_) is *false*, return *false*.
       1. If _index_ is *-0*<sub>𝔽</sub>, return *false*.
-      1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_) is *true*, return *false*.</ins>
-      1. If ℝ(_index_) &lt; 0 or ℝ(_index_) &ge; <del>_O_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_O_)</ins>, return *false*.
+      1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+      1. <ins>NOTE: Bounds checking is not a synchronizing operation when _O_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
+      1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return *false*.</ins>
+      1. If ℝ(_index_) &lt; 0 or ℝ(_index_) &ge; <del>_O_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_O_, _getBufferByteLength_)</ins>, return *false*.
       1. Return *true*.
     </emu-alg>
   </emu-clause>
 
   <ins class="block">
   <emu-clause id="sec-integerindexedobjectbytelength" aoid="IntegerIndexedObjectByteLength">
-    <h1>IntegerIndexedObjectByteLength ( _O_ )</h1>
-    <p>The abstract operation IntegerIndexedObjectByteLength takes arguments _O_. It performs the following steps when called:</p>
+    <h1>IntegerIndexedObjectByteLength ( _O_, _getBufferByteLength_ )</h1>
+    <p>The abstract operation IntegerIndexedObjectByteLength takes arguments _O_ and _getBufferByteLength_. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _O_ is an Integer-Indexed exotic object.
-      1. If CheckIntegerIndexedObjectOutOfBounds(_O_) is *true*, return 0.
+      1. Let _length_ be IntegerIndexedObjectLength(_O_, _getBufferByteLength_).
+      1. If _length_ = 0, return 0.
       1. If _O_.[[ByteLength]] is not ~auto~, return _O_.[[ByteLength]].
       1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
-      1. Return IntegerIndexedObjectLength(_O_) &times; _elementSize_.
+      1. Return _length_ &times; _elementSize_.
     </emu-alg>
     </emu-clause>
 
   <emu-clause id="sec-integerindexedobjectlength" aoid="IntegerIndexedObjectLength">
-    <h1>IntegerIndexedObjectLength ( _O_ )</h1>
-    <p>The abstract operation IntegerIndexedObjectLength takes arguments _O_. It performs the following steps when called:</p>
+    <h1>IntegerIndexedObjectLength ( _O_, _getBufferByteLength_ )</h1>
+    <p>The abstract operation IntegerIndexedObjectLength takes arguments _O_ and _getBufferByteLength_. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _O_ is an Integer-Indexed exotic object.
-      1. If CheckIntegerIndexedObjectOutOfBounds(_O_) is *true*, return 0.
+      1. If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return 0.
       1. If _O_.[[ArrayLength]] is not ~auto~, return _O_.[[ArrayLength]].
       1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
+      1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).
       1. Assert: IsResizableArrayBuffer(_buffer_) is *true*.
-      1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_).
       1. Let _byteOffset_ be _O_.[[ByteOffset]].
       1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
       1. Let _length_ be floor((_bufferByteLength_ - _byteOffset_) / _elementSize_).
@@ -583,12 +604,12 @@
   </emu-clause>
 
   <emu-clause id="sec-checkintegerindexedobjectoutofbounds" aoid="CheckIntegerIndexedObjectOutOfBounds">
-    <h1>CheckIntegerIndexedObjectOutOfBounds ( _O_ )</h1>
-    <p>The abstract operation CheckIntegerIndexedObjectOutOfBounds takes arguments _O_. It checks if any part of the underlying viewed buffer is out of bounds. It performs the following steps when called:</p>
+    <h1>CheckIntegerIndexedObjectOutOfBounds ( _O_, _getBufferByteLength_ )</h1>
+    <p>The abstract operation CheckIntegerIndexedObjectOutOfBounds takes arguments _O_ and _getBufferByteLength_. It checks if any part of the underlying viewed buffer is out of bounds. It performs the following steps when called:</p>
     <emu-alg>
       1. Assert: _O_ is an Integer-Indexed exotic object.
       1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
-      1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_).
+      1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).
       1. Let _byteOffsetStart_ be _O_.[[ByteOffset]].
       1. If _O_.[[ArrayLength]] is ~auto~, then
         1. Let _byteOffsetEnd_ be _bufferByteLength_.
@@ -616,7 +637,8 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Return _buffer_.
       </emu-alg>
     </emu-clause>
@@ -630,7 +652,8 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>IntegerIndexedObjectByteLength(_O_)</ins>.
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>IntegerIndexedObjectByteLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_size_).
       </emu-alg>
     </emu-clause>
@@ -644,7 +667,8 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_) is *true*, return *+0*<sub>𝔽</sub>.</ins>
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_O_, _getBufferByteLength_) is *true*, return *+0*<sub>𝔽</sub>.</ins>
         1. Let _offset_ be _O_.[[ByteOffset]].
         1. Return 𝔽(_offset_).
       </emu-alg>
@@ -659,7 +683,8 @@
         1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
-        1. Let _length_ be <del>_O_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_O_)</ins>.
+        1. Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).
+        1. Let _length_ be <del>_O_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_length_).
       </emu-alg>
       <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -672,10 +697,11 @@
         1. Assert: _source_ is an Object that has a [[TypedArrayName]] internal slot.
         1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-        1. Let _targetLength_ be <del>_target_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_target_)</ins>.
+        1. <ins>Let _getSrcBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. Let _targetLength_ be <del>_target_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_target_, _getBufferByteLength_)</ins>.
         1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_target_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_target_, getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
         1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
         1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
@@ -692,7 +718,7 @@
           1. If _srcBuffer_.[[ArrayBufferData]] and _targetBuffer_.[[ArrayBufferData]] are the same Shared Data Block values, let _same_ be *true*; else let _same_ be *false*.
         1. Else, let _same_ be SameValue(_srcBuffer_, _targetBuffer_).
         1. If _same_ is *true*, then
-          1. Let _srcByteLength_ be <del>_source_.[[ByteLength]]</del><ins>IntegerIndexedObjectByteLength(_source_)</ins>.
+          1. Let _srcByteLength_ be <del>_source_.[[ByteLength]]</del><ins>IntegerIndexedObjectByteLength(_source_, _getSrcBufferByteLength_)</ins>.
           1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_, %ArrayBuffer%).
           1. NOTE: %ArrayBuffer% is used to clone _srcBuffer_ because is it known to not have any observable side-effects.
           1. Let _srcByteIndex_ be 0.
@@ -729,7 +755,8 @@
         1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
         1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
-        1. Let _elementLength_ be <del>_srcArray_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_srcArray_)</ins>.
+        1. <ins>Let _getSrcBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. Let _elementLength_ be <del>_srcArray_.[[ArrayLength]]</del><ins>IntegerIndexedObjectLength(_srcArray_, _getSrcBufferByteLength_)</ins>.
         1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
         1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
         1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
@@ -745,7 +772,7 @@
         1. Else,
           1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
           1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-          1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_srcArray_) is *true*, throw a *TypeError* exception.</ins>
+          1. <ins>If CheckIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
           1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
           1. Let _srcByteIndex_ be _srcByteOffset_.
           1. Let _targetByteIndex_ be 0.
@@ -777,7 +804,7 @@
         1. If _length_ is not *undefined*, then
           1. Let _newLength_ be ? ToIndex(_length_).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. Let _bufferByteLength_ be <del>_buffer_.[[ArrayBufferByteLength]]</del><ins>ArrayBufferByteLength(_buffer_).</ins>.
+        1. Let _bufferByteLength_ be <del>_buffer_.[[ArrayBufferByteLength]]</del><ins>ArrayBufferByteLength(_buffer_, ~SeqCst~).</ins>.
         1. <ins>If _length_ is *undefined* and _bufferIsResizable_ is *true*, then</ins>
           1. <ins>If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.</ins>
           1. <ins>Set _O_.[[ByteLength]] to ~auto~.</ins>
@@ -809,24 +836,24 @@
 
     <ins class="block">
     <emu-clause id="sec-getviewbytelength" aoid="GetViewByteLength">
-      <h1>GetViewByteLength ( _view_ )</h1>
-      <p>The abstract operation GetViewByteLength takes argument _view_. It performs the following steps when called:</p>
+      <h1>GetViewByteLength ( _view_, _getBufferByteLength_ )</h1>
+      <p>The abstract operation GetViewByteLength takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
       <emu-alg>
         1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
         1. If _view_.[[ByteLength]] is not ~auto~, then return _view_.[[ByteLength]].
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
-        1. Return ArrayBufferByteLength(_buffer_).
+        1. Return _getBufferByteLength_(_buffer_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-checkviewoutofbounds" aoid="CheckViewOutOfBounds">
-      <h1>CheckViewOutOfBounds ( _view_ )</h1>
-      <p>The abstract operation CheckViewOutOfBounds takes argument _view_. It performs the following steps when called:</p>
+      <h1>CheckViewOutOfBounds ( _view_, _getBufferByteLength_ )</h1>
+      <p>The abstract operation CheckViewOutOfBounds takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
       <emu-alg>
         1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
-        1. Let _byteLength_ be GetViewByteLength(_view_).
+        1. Let _byteLength_ be GetViewByteLength(_view_, _getBufferByteLength_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
-        1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_).
+        1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).
         1. If _view_.[[ByteOffset]] + _byteLength_ &gt; _bufferByteLength_, then return *true*.
         1. Return *false*.
       </emu-alg>
@@ -843,9 +870,11 @@
         1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckViewOutOfBounds(_view_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+        1. <ins>NOTE: Bounds checking is not a synchronizing operation when _view_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
+        1. <ins>If CheckViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _viewOffset_ be _view_.[[ByteOffset]].
-        1. Let _viewSize_ be <del>_view_.[[ByteLength]]</del><ins>GetViewByteLength(_view_)</ins>.
+        1. Let _viewSize_ be <del>_view_.[[ByteLength]]</del><ins>GetViewByteLength(_view_, _getBufferByteLength_)</ins>.
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
         1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
         1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
@@ -865,9 +894,11 @@
         1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckViewOutOfBounds(_view_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
+        1. <ins>NOTE: Bounds checking is not a synchronizing operation when _view_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
+        1. <ins>If CheckViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _viewOffset_ be _view_.[[ByteOffset]].
-        1. Let _viewSize_ be <del>_view_.[[ByteLength]]</del><ins>GetViewByteLength(_view_)</ins>.
+        1. Let _viewSize_ be <del>_view_.[[ByteLength]]</del><ins>GetViewByteLength(_view_, _getBufferByteLength_)</ins>.
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
         1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
         1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
@@ -887,7 +918,7 @@
         1. Perform ? RequireInternalSlot(_buffer_, [[ArrayBufferData]]).
         1. Let _offset_ be ? ToIndex(_byteOffset_).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. Let _bufferByteLength_ be <del>_buffer_.[[ArrayBufferByteLength]]</del><ins>ArrayBufferByteLength(_buffer_).</ins>.
+        1. Let _bufferByteLength_ be <del>_buffer_.[[ArrayBufferByteLength]]</del><ins>ArrayBufferByteLengthGetter(_buffer_, ~SeqCst~).</ins>.
         1. If _offset_ &gt; _bufferByteLength_, throw a *RangeError* exception.
         1. <ins>Let _bufferIsResizable_ be IsResizableArrayBuffer(_buffer_).</ins>
         1. <ins>If _bufferIsResizable_ is *true* and _byteLength_ is *undefined*, then</ins>
@@ -919,8 +950,9 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckViewOutOfBounds(_O_) is *true*, throw a *TypeError* exception.</ins>
-        1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>GetViewByteLength(_O_)</ins>.
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>If CheckViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>GetViewByteLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_size_).
       </emu-alg>
     </emu-clause>
@@ -934,7 +966,8 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-        1. <ins>If CheckViewOutOfBounds(_O_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
+        1. <ins>If CheckViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _offset_ be _O_.[[ByteOffset]].
         1. Return 𝔽(_offset_).
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -846,9 +846,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-checkviewoutofbounds" aoid="CheckViewOutOfBounds">
-      <h1>CheckViewOutOfBounds ( _view_, _getBufferByteLength_ )</h1>
-      <p>The abstract operation CheckViewOutOfBounds takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
+    <emu-clause id="sec-isviewoutofbounds" aoid="IsViewOutOfBounds">
+      <h1>IsViewOutOfBounds ( _view_, _getBufferByteLength_ )</h1>
+      <p>The abstract operation IsViewOutOfBounds takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
       <emu-alg>
         1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
         1. Let _byteLength_ be GetViewByteLength(_view_, _getBufferByteLength_).
@@ -872,7 +872,7 @@
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
         1. <ins>NOTE: Bounds checking is not a synchronizing operation when _view_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
-        1. <ins>If CheckViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>If IsViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _viewOffset_ be _view_.[[ByteOffset]].
         1. Let _viewSize_ be <del>_view_.[[ByteLength]]</del><ins>GetViewByteLength(_view_, _getBufferByteLength_)</ins>.
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
@@ -896,7 +896,7 @@
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~Unordered~).</ins>
         1. <ins>NOTE: Bounds checking is not a synchronizing operation when _view_'s backing buffer is a GrowableSharedArrayBuffer.</ins>
-        1. <ins>If CheckViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>If IsViewOutOfBounds(_view_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _viewOffset_ be _view_.[[ByteOffset]].
         1. Let _viewSize_ be <del>_view_.[[ByteLength]]</del><ins>GetViewByteLength(_view_, _getBufferByteLength_)</ins>.
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
@@ -951,7 +951,7 @@
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
-        1. <ins>If CheckViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>If IsViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>GetViewByteLength(_O_, _getBufferByteLength_)</ins>.
         1. Return 𝔽(_size_).
       </emu-alg>
@@ -967,7 +967,7 @@
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. <ins>Let _getBufferByteLength_ be ! MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
-        1. <ins>If CheckViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>If IsViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Let _offset_ be _O_.[[ByteOffset]].
         1. Return 𝔽(_offset_).
       </emu-alg>


### PR DESCRIPTION
Closes #27.

All other operations are SeqCst, while indexed get and set are relaxed
to Unordered. This aligns with wasm and also gives implementations
greater latitude in implementing indexed access on TAs backed by GSABs.

It is an invariant of that there is a single shared memory read of the
byteLength per buffer per higher level operation (e.g. `TA#slice`). To
make this easier across various AOs that do bounds checking, there is
the MakeIdempotentArrayBufferByteLength AO that returns an AC that makes
getting the byteLength idempotent.