### PR TITLE
Normative: require [[ArrayBufferData]] internal slot

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -153,6 +153,7 @@
       <p>`ArrayBuffer.prototype.resizable` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _O_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
         1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
         1. Return IsResizableArrayBuffer(_O_).
       </emu-alg>
@@ -301,6 +302,7 @@
       <p>`SharedArrayBuffer.prototype.growable` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _O_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
         1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
         1. Return IsResizableArrayBuffer(_O_).
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -187,6 +187,7 @@
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _O_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
         1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
         1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
         1. If _newLength_ is *undefined*, let _newByteLength_ be _O_.[[ArrayBufferByteLength]].


### PR DESCRIPTION
The existing `byteLength` accessor functions on both ArrayBuffer and
SharedArrayBuffer require the *this* value to have the
[[ArrayBufferData]] internal slot, as do the `maxByteLength` accessor
functions defined by this proposal.

Additionally, the abstract operations in use within the `resizable` and
`growable` accessor methods include invariants regarding the presence of
the [[ArrayBufferData]] internal slot.

Update the `resizable` and `growable` accessor methods to require the
[[ArrayBufferData]] internal slot to promote consistency with other APIs
and to satisfy the invariants of abstract operations.

---

The abstract operations in use within the `transfer` method include
invariants regarding the presence of the [[ArrayBufferData]] internal
slot. Update the algorithm to require the [[ArrayBufferData]] internal
slot to to satisfy the invariants of abstract operations.