### PR TITLE
Normative: correct TypedArray boundary checks

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -464,8 +464,8 @@
         1. Let _byteOffsetEnd_ be _bufferByteLength_.
       1. Else,
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
-        1. Let _byteOffsetEnd_ be _O_.[[ArrayLength]] &times; _elementSize_.
-      1. If _byteOffsetStart_ &ge; _bufferByteLength_ or _byteOffsetEnd_ &ge; _bufferByteLength_, then return *true*.
+        1. Let _byteOffsetEnd_ be _bytOffsetStart_ + _O_.[[ArrayLength]] &times; _elementSize_.
+      1. If _byteOffsetStart_ &ge; _bufferByteLength_ or _byteOffsetEnd_ &gt; _bufferByteLength_, then return *true*.
       1. Return *false*.
     </emu-alg>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -464,7 +464,7 @@
         1. Let _byteOffsetEnd_ be _bufferByteLength_.
       1. Else,
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
-        1. Let _byteOffsetEnd_ be _bytOffsetStart_ + _O_.[[ArrayLength]] &times; _elementSize_.
+        1. Let _byteOffsetEnd_ be _byteOffsetStart_ + _O_.[[ArrayLength]] &times; _elementSize_.
       1. If _byteOffsetStart_ &ge; _bufferByteLength_ or _byteOffsetEnd_ &gt; _bufferByteLength_, then return *true*.
       1. Return *false*.
     </emu-alg>


### PR DESCRIPTION
The "byteOffsetEnd" variable is ostensibly intended to describe the
first invalid index in the underlying ArrayBuffer. When deriving this
value for fixed-length TypedArray instances, it should take into account
not only the instance's length and "element size" but also the
instance's offset into the ArrayBuffer.

When this value is equal to the underlying ArrayBuffer's "byte length,"
the TypedArray is within bounds.

Update the calculation of "byteOffsetEnd" for fixed-length TypedArray
instances, and label maximally-sized TypedArray instances as within
bounds.