### PR TITLE
Editorial: remove superfluous brand checks

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -689,7 +689,7 @@
       <h1>GetViewByteLength ( _view_, _getBufferByteLength_ )</h1>
       <p>The abstract operation GetViewByteLength takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
       <emu-alg>
-        1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
+        1. Assert: Type(_view_) is Object and _view_ has a [[DataView]] internal slot.
         1. If _view_.[[ByteLength]] is not ~auto~, then return _view_.[[ByteLength]].
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
         1. Return _getBufferByteLength_(_buffer_).
@@ -700,7 +700,7 @@
       <h1>IsViewOutOfBounds ( _view_, _getBufferByteLength_ )</h1>
       <p>The abstract operation IsViewOutOfBounds takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
       <emu-alg>
-        1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
+        1. Assert: Type(_view_) is Object and _view_ has a [[DataView]] internal slot.
         1. Let _byteLength_ be GetViewByteLength(_view_, _getBufferByteLength_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
         1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).


### PR DESCRIPTION
The IsViewOutOfBounds abstract operation has four call sites:

- GetViewValue
- SetViewValue
- DataView.prototype.byteLength
- DataView.prototype.byteOffset

Every call site is preceeded by the following step:

> Perform ? RequireInternalSlot(view, [[DataView]]).

Which makes validating the "brand" unnecessary.

Similarly, the GetViewByteLength abstract operation has four call sites:

- IsViewOutOfBounds
- GetViewValue
- SetViewValue
- DataView.prototype.byteLength

These are likewise preceded by the [[DataView]] brand check.

Replace the brand checks with assertions to make this invariant clear to
readers.