### PR TITLE
Normative: Don't consider 0-length TypedArrays out of bounds

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -481,7 +481,8 @@
       1. Else,
         1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
         1. Let _byteOffsetEnd_ be _byteOffsetStart_ + _O_.[[ArrayLength]] &times; _elementSize_.
-      1. If _byteOffsetStart_ &ge; _bufferByteLength_ or _byteOffsetEnd_ &gt; _bufferByteLength_, then return *true*.
+      1. If _byteOffsetStart_ &gt; _bufferByteLength_ or _byteOffsetEnd_ &gt; _bufferByteLength_, then return *true*.
+      1. NOTE: 0-length TypedArrays are not considered out-of-bounds.
       1. Return *false*.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
Closes #68