### PR TITLE
Normative: throw whenever creating TA from OOB TA

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -759,6 +759,7 @@
         1. Else,
           1. Let _bufferConstructor_ be %ArrayBuffer%.
         1. <ins>Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).</ins>
+        1. <ins>Let _getSrcBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
         1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. <ins>Set _elementLength_ to IntegerIndexedObjectLength(_srcArray_, _getSrcBufferByteLength_).</ins>
         1. <ins>Set _byteLength_ to _elementSize_ &times; _elementLength_.</ins>
@@ -766,7 +767,8 @@
           1. <del>Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).</del>
           1. <ins>Let _srcBlock_ be _srcData_.[[ArrayBufferData]].</ins>
           1. <ins>Let _targetBlock_ be _data_.[[ArrayBufferData]].</ins>
-          1. <ins>Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _byteLength_).</ins>
+          1. <ins>Let _count_ be min(_byteLength_, _data_.[[ArrayBufferByteLength]]).</ins>
+          1. <ins>Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _count_).</ins>
         1. Else,
           1. <del>Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).</del>
           1. <del>If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.</del>

--- a/spec.html
+++ b/spec.html
@@ -758,13 +758,18 @@
           1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
         1. Else,
           1. Let _bufferConstructor_ be %ArrayBuffer%.
+        1. <ins>Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).</ins>
+        1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+        1. <ins>Set _elementLength_ to IntegerIndexedObjectLength(_srcArray_, _getSrcBufferByteLength_).</ins>
+        1. <ins>Set _byteLength_ to _elementSize_ &times; _elementLength_.</ins>
         1. If _elementType_ is the same as _srcType_, then
-          1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
-          1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
+          1. <del>Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).</del>
+          1. <ins>Let _srcBlock_ be _srcData_.[[ArrayBufferData]].</ins>
+          1. <ins>Let _targetBlock_ be _data_.[[ArrayBufferData]].</ins>
+          1. <ins>Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _byteLength_).</ins>
         1. Else,
-          1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
+          1. <del>Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).</del>
           1. <del>If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.</del>
-          1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
           1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
           1. Let _srcByteIndex_ be _srcByteOffset_.
           1. Let _targetByteIndex_ be 0.

--- a/spec.html
+++ b/spec.html
@@ -760,6 +760,7 @@
           1. Let _bufferConstructor_ be %ArrayBuffer%.
         1. If _elementType_ is the same as _srcType_, then
           1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
+          1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
         1. Else,
           1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
           1. <del>If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.</del>


### PR DESCRIPTION
Resolves gh-57. Duplicating the boundary-checking step seems like the most straightforward solution to me. Alternatively, we could interrupt the branches to perform the bounds checking that's common to both:

    1. If _elementType_ is the same as _srcType_, then
      1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
    1. Else,
      1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
    1. <ins>If IsIntegerIndexedObjectOutOfBounds(_srcArray_, _getSrcBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
    1. <ins>If _elementType_ is not the same as _srcType_, then</ins>
      1. <del>If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.</del>
      [...]