### PR TITLE
Editorial: communicate operation fallibility

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -227,7 +227,7 @@
         1. Let _toBlock_ be _new_.[[ArrayBufferData]].
         1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, 0, _copyLength_).
         1. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations reserve the right to implement this method as a zero-copy move or a `realloc`.
-        1. Perform ! DetachArrayBuffer(_O_).
+        1. Perform ? DetachArrayBuffer(_O_).
         1. Return _new_.
       </emu-alg>
       <emu-note>


### PR DESCRIPTION
DeatchArrayBuffer will return an abrupt "throw" completion if the buffer
has been created by an embedding environment which set the
[[ArrayBufferDetachKey]] internal slot to a value other than
`undefined`.

---

I believe that this could be observed by calling `transfer` on [an ArrayBuffer created by the WebAssembly JavaScript Interface](https://webassembly.github.io/spec/js-api/#create-a-memory-buffer), but even if not, I don't know if we can rule out the condition in general.

For what it's worth, [the withdrawn proposal for `ArrayBuffer.prototype.transfer`](https://domenic.github.io/proposal-arraybuffer-transfer/) accounted for the possibility. On the other hand, this proposal has labelled the operation as "infallible" [since the spec text was first written](https://github.com/tc39/proposal-resizablearraybuffer/commit/ede41a5fab7883b167c13e579380382ff524c30f#diff-181371b08d71216599b0acccbaabd03c306da6de142ea6275c2135810999805aR205).