### PR TITLE
Editorial: correct DataView length & boundary

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -833,7 +833,8 @@
         1. Assert: Type(_view_) is Object and _view_ has a [[DataView]] internal slot.
         1. If _view_.[[ByteLength]] is not ~auto~, then return _view_.[[ByteLength]].
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
-        1. Return _getBufferByteLength_(_buffer_).
+        1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).
+        1. Return _bufferByteLength_ - _view_.[[ByteOffset]].
       </emu-alg>
     </emu-clause>
 
@@ -842,11 +843,10 @@
       <p>The abstract operation IsViewOutOfBounds takes arguments _view_ and _getBufferByteLength_. It performs the following steps when called:</p>
       <emu-alg>
         1. Assert: Type(_view_) is Object and _view_ has a [[DataView]] internal slot.
-        1. Let _byteLength_ be GetViewByteLength(_view_, _getBufferByteLength_).
         1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
-        1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, return *true*.
-        1. Let _bufferByteLength_ be _getBufferByteLength_(_buffer_).
-        1. If _view_.[[ByteOffset]] + _byteLength_ &gt; _bufferByteLength_, then return *true*.
+        1. If IsDetachedBuffer(_buffer_) is *true*, return *true*.
+        1. Let _byteLength_ be GetViewByteLength(_view_, _getBufferByteLength_).
+        1. If _byteLength &lt; 0, then return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Prior to this patch, the GetViewByteLength abstract operation returned
the length of the underlying buffer. This value would only be accurate
if the DataView had a byte offset of zero. Update the algorithm to
take the DataView's byte offset into account.

Prior to this patch, the IsViewOutOfBounds abstract operation relied on
the GetViewByteLength abstract operation to provide an accurate value
for the byte length of the DataView. The algorithm was incorrect when it
used the incorrect version of GetViewByteLength, but the correction to
GetViewByteLength is not sufficient to correct this abstract operation.
Update the algorithm to report whether the updated version of
GetViewByteLength returns a valid value.

Replace the reference to the non-existent specification variable "O"
with a reference to the specification variable "buffer".