### PR TITLE
bump ecmarkup to 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"license": "MIT",
 	"devDependencies": {
-		"ecmarkup": "^15.0.4",
-		"@tc39/ecma262-biblio": "2.1.2474"
+		"ecmarkup": "^16.0.0",
+		"@tc39/ecma262-biblio": "2.1.2478"
 	}
 }


### PR DESCRIPTION
This fixes the lint error by inclusion of https://github.com/tc39/ecmarkup/pull/498.