### PR TITLE
Editorial: Remove duplicate IsViewOutOfBounds calls in DataView.prototype.byteLength

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1210,9 +1210,10 @@
         1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
         1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
         1. <del>If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.</del>
+        1. <del>Let _size_ be _O_.[[ByteLength]].</del>
         1. <ins>Let _getBufferByteLength_ be MakeIdempotentArrayBufferByteLengthGetter(~SeqCst~).</ins>
-        1. <ins>If IsViewOutOfBounds(_O_, _getBufferByteLength_) is *true*, throw a *TypeError* exception.</ins>
-        1. Let _size_ be <del>_O_.[[ByteLength]]</del><ins>GetViewByteLength(_O_, _getBufferByteLength_)</ins>.
+        1. <ins>Let _size_ be GetViewByteLength(_O_, _getBufferByteLength_).</ins>
+        1. <ins>If _size_ is ~out-of-bounds~, throw a *TypeError* exception.</ins>
         1. Return 𝔽(_size_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
`GetViewByteLength` calls `IsViewOutOfBounds` as its first step, so it's not necessary to call `IsViewOutOfBounds` in
`DataView.prototype.byteLength`.