### PR TITLE
Normative: Check for detached buffers before calling HostResizeArrayBuffer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -276,6 +276,7 @@
         1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
         1. Let _newByteLength_ be ? ToIntegerOrInfinity(_newLength_).
         1. If _newByteLength_ &lt; 0 or _newByteLength_ &gt; _O_.[[ArrayBufferMaxByteLength]], throw a *RangeError* exception.
+        1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
         1. Let _hostHandled_ be ? HostResizeArrayBuffer(_O_, _newByteLength_).
         1. If _hostHandled_ is ~handled~, return *undefined*.
         1. Let _oldBlock_ be _O_.[[ArrayBufferData]].


### PR DESCRIPTION
`ToIntegerOrInfinity` can detach the buffer, adding an explicit `IsDetachedBuffer` call makes it more clear which error should be thrown in that case.